### PR TITLE
Feature/telnetd

### DIFF
--- a/.choices
+++ b/.choices
@@ -29,4 +29,8 @@ docker run -it --name httpd -v apache2:/usr/local/apache2 --network my-net httpd
 ----
 docker run -it --name try -v apache2:/usr/local/apache2 --network my-net httpd bash
 ----
-sudo /home/lclose/.virtualenvs/venv1/bin/python3 -m src
+docker build -t debian:telnetd . -f docker_files/telnetd/Dockerfile
+docker build --no-cache -t debian:telnetd . -f docker_files/telnetd/Dockerfile
+docker save -o debian:telnetd.tar debian:telnetd
+docker load -i debian:telnetd.tar
+docker run -p 23:23 debian:telnetd

--- a/containers.yml
+++ b/containers.yml
@@ -1,6 +1,6 @@
 ---
 container: 'httpd:latest'
-# listen_address: '127.0.0.1'
+listen_address: '0.0.0.0'
 listen_port: 80
 request_length: 4096
 request_commands: 4
@@ -13,4 +13,13 @@ listen_address: '127.0.0.1'
 listen_port: 443
 request_length: 4096
 TLS: true
+threads: 2
+---
+container: 'debian:telnetd'
+listen_address: '0.0.0.0'
+listen_port: 23
+request_length: 4096
+request_commands: 4
+request_delimiters:
+    - '\r\n'
 threads: 2

--- a/docker_files/telnetd/.choices
+++ b/docker_files/telnetd/.choices
@@ -1,2 +1,11 @@
-docker build -t debian:telnetd .
+docker stop $(docker ps -a -q)
+
+docker rm $(docker ps -a -q)
+
+docker system prune -a
+
+docker rmi $(docker images -a -q)
+---
+docker build --no-cache -t debian:telnetd .
+
 docker run -p 23:23 debian:telnetd

--- a/docker_files/telnetd/Dockerfile
+++ b/docker_files/telnetd/Dockerfile
@@ -1,8 +1,35 @@
 FROM debian:latest
 EXPOSE 23
+
 RUN apt update && apt -y install inetutils-telnetd
 RUN echo 'telnet stream tcp nowait root /usr/sbin/tcpd /usr/sbin/telnetd' >> /etc/inetd.conf
-RUN useradd foo
-RUN usermod -aG sudo foo
-RUN echo 'foo:bar' | chpasswd
-CMD ["/usr/sbin/inetutils-inetd","-d"]
+RUN echo 'pts/0' >> /etc/securetty
+RUN echo 'pts/1' >> /etc/securetty
+RUN echo 'pts/2' >> /etc/securetty
+RUN echo 'pts/3' >> /etc/securetty
+RUN echo 'pts/4' >> /etc/securetty
+RUN echo 'pts/5' >> /etc/securetty
+RUN echo 'pts/6' >> /etc/securetty
+RUN echo 'pts/7' >> /etc/securetty
+RUN echo 'pts/8' >> /etc/securetty
+RUN echo 'pts/9' >> /etc/securetty
+RUN echo '+:root:ALL' >> /etc/security/access.conf
+RUN echo '+:ALL:ALL' >> /etc/security/access.conf
+RUN echo 'NO_PASSWORD_CONSOLE' >> /etc/login.defs
+RUN sed "s/pam_unix.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_limits.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_time.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_deny.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_loginuid.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_nologin.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_rootok.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_keyinit.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_lastlog.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_shells.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_env.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_selinux.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_systemd.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_group.so/pam_permit.so/g" -i /etc/pam.d/*
+RUN sed "s/pam_securetty.so/pam_permit.so/g" -i /etc/pam.d/*
+
+CMD [ "/usr/sbin/inetutils-inetd","-d"]


### PR DESCRIPTION
Telnetd container working with user login root. Containers.yaml working with for all three currently configured(this could use some more attention as the defaults are used in many places where perhaps a defined value could be better). Commands to build the telnetd container are in HPotter/.choices and HPotter/docker_files/telnetd/.choices

docker build -t debian:telnetd . -f docker_files/telnetd/Dockerfile

Then will run with HPotter from containers. Experimented with prebuilding and compressing the image but have not included.