### PR TITLE
No talk

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -42,7 +42,6 @@ class HP():
         chain.add_connection_rules()
         chain.add_dns_rules()
         chain.add_ssh_rules()
-        chain.add_docker_rules()
 
     def startup(self):
         ''' Read the configuration and start the listen threads. '''

--- a/src/chain.py
+++ b/src/chain.py
@@ -167,12 +167,10 @@ def add_ssh_rules(): #allow LAN/LocalHost IPs, reject all others
 
 def create_container_rules(obj):
     thread_lock.acquire()
-    
     proto = obj.container_protocol.lower()
     source_addr = obj.container_gateway
     dest_addr = obj.container_ip
     dstport = str(obj.container_port)
-
     obj.to_rule = { \
             'src': source_addr, \
             'dst': dest_addr, \
@@ -181,8 +179,12 @@ def create_container_rules(obj):
             proto: {'dport': dstport} \
     }
     logger.debug(obj.to_rule)
-    iptc.easy.insert_rule('filter', 'hpotter_output', obj.to_rule)
-
+    try:
+        iptc.easy.insert_rule('filter', 'hpotter_output', obj.to_rule)
+    except Exception as err:
+        logger.debug(error)
+        pass
+    
     obj.from_rule = { \
             'src': dest_addr, \
             'dst': source_addr, \
@@ -191,8 +193,11 @@ def create_container_rules(obj):
             proto: {'sport': dstport} \
     }
     logger.debug(obj.from_rule)
-    iptc.easy.insert_rule('filter', 'hpotter_input', obj.from_rule)
-
+    try:
+        iptc.easy.insert_rule('filter', 'hpotter_input', obj.from_rule)
+    except Exception as err:
+        logger.debug(err)
+        pass
     thread_lock.release()
 
 def delete_container_rules(obj):

--- a/src/chain.py
+++ b/src/chain.py
@@ -165,15 +165,45 @@ def add_ssh_rules(): #allow LAN/LocalHost IPs, reject all others
     logger.debug(local_d)
     iptc.easy.insert_rule('filter', 'hpotter_input', local_d)
 
-def add_docker_rules():
-    network = configs.get('docker_subnet', '')
-    d_rule = { \
-        'src': network, \
-        'dst': network, \
-        'target': 'ACCEPT' \
+def create_container_rules(obj):
+    thread_lock.acquire()
+    
+    proto = obj.container_protocol.lower()
+    source_addr = obj.container_gateway
+    dest_addr = obj.container_ip
+    dstport = str(obj.container_port)
+
+    obj.to_rule = { \
+            'src': source_addr, \
+            'dst': dest_addr, \
+            'target': 'ACCEPT', \
+            'protocol': proto, \
+            proto: {'dport': dstport} \
     }
-    iptc.easy.insert_rule('filter', 'hpotter_input', d_rule)
-    iptc.easy.insert_rule('filter', 'hpotter_output', d_rule)
+    logger.debug(obj.to_rule)
+    iptc.easy.insert_rule('filter', 'hpotter_output', obj.to_rule)
+
+    obj.from_rule = { \
+            'src': dest_addr, \
+            'dst': source_addr, \
+            'target': 'ACCEPT', \
+            'protocol': proto, \
+            proto: {'sport': dstport} \
+    }
+    logger.debug(obj.from_rule)
+    iptc.easy.insert_rule('filter', 'hpotter_input', obj.from_rule)
+
+    thread_lock.release()
+
+def delete_container_rules(obj):
+    thread_lock.acquire()
+
+    logger.debug('Removing rules')
+
+    iptc.easy.delete_rule('filter', "hpotter_output", obj.to_rule)
+    iptc.easy.delete_rule('filter', "hpotter_input", obj.from_rule)
+
+    thread_lock.release()
 
 def get_host_ip():
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/test/test_chain.py
+++ b/test/test_chain.py
@@ -126,6 +126,43 @@ class TestChain(unittest.TestCase):
         self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_forward', resolv1))
         self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_forward', resolv2))
     
+#def test_create_container_rules(self):
+#        cont_mock = unittest.mock.Mock()
+#        cont_mock.container_protocol = 'tcp'
+#        cont_mock.container_gateway = "71.88.115.9"
+#        cont_mock.container_ip = "192.188.72.83"
+#        cont_mock.container_port = 202
+#        create_container_rules(cont_mock)
+#        source = cont_mock.container_gateway
+#        dest = cont_mock.container_ip
+#        proto = cont_mock.container_protocol
+#        port = str(cont_mock.container_port)
+#        rule_t = { \
+#                'src': source, \
+#                'dst': dest, \
+#                'target': 'ACCEPT', \
+#                'protocol': proto, \
+#                proto: {'dport': port} \
+#        }
+#        rule_f = { \
+#                'src': dest, \
+#                'dst': source, \
+#                'target': 'ACCEPT', \
+#                'protocol': proto, \
+#                proto: {'sport': port} \
+#        }
+#    
+#        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
+#        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
+#
+#        cont_mock.to_rule = rule_t
+#        cont_mock.from_rule = rule_f
+#        cont_mock.drop_rule = drop
+#        delete_container_rules(cont_mock)
+#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
+#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
+#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', drop) )
+
     def test_flush(self):
         flush_chains()
         for chain in builtin_chains:

--- a/test/test_chain.py
+++ b/test/test_chain.py
@@ -157,11 +157,9 @@ class TestChain(unittest.TestCase):
 #
 #        cont_mock.to_rule = rule_t
 #        cont_mock.from_rule = rule_f
-#        cont_mock.drop_rule = drop
 #        delete_container_rules(cont_mock)
 #        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
 #        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
-#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', drop) )
 
     def test_flush(self):
         flush_chains()

--- a/test/test_chain.py
+++ b/test/test_chain.py
@@ -126,40 +126,40 @@ class TestChain(unittest.TestCase):
         self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_forward', resolv1))
         self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_forward', resolv2))
     
-#def test_create_container_rules(self):
-#        cont_mock = unittest.mock.Mock()
-#        cont_mock.container_protocol = 'tcp'
-#        cont_mock.container_gateway = "71.88.115.9"
-#        cont_mock.container_ip = "192.188.72.83"
-#        cont_mock.container_port = 202
-#        create_container_rules(cont_mock)
-#        source = cont_mock.container_gateway
-#        dest = cont_mock.container_ip
-#        proto = cont_mock.container_protocol
-#        port = str(cont_mock.container_port)
-#        rule_t = { \
-#                'src': source, \
-#                'dst': dest, \
-#                'target': 'ACCEPT', \
-#                'protocol': proto, \
-#                proto: {'dport': port} \
-#        }
-#        rule_f = { \
-#                'src': dest, \
-#                'dst': source, \
-#                'target': 'ACCEPT', \
-#                'protocol': proto, \
-#                proto: {'sport': port} \
-#        }
-#    
-#        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
-#        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
-#
-#        cont_mock.to_rule = rule_t
-#        cont_mock.from_rule = rule_f
-#        delete_container_rules(cont_mock)
-#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
-#        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
+    def test_create_container_rules(self):
+        cont_mock = unittest.mock.Mock()
+        cont_mock.container_protocol = 'tcp'
+        cont_mock.container_gateway = "71.88.115.9"
+        cont_mock.container_ip = "192.188.72.83"
+        cont_mock.container_port = 202
+        create_container_rules(cont_mock)
+        source = cont_mock.container_gateway
+        dest = cont_mock.container_ip
+        proto = cont_mock.container_protocol
+        port = str(cont_mock.container_port)
+        rule_t = { \
+                'src': source, \
+                'dst': dest, \
+                'target': 'ACCEPT', \
+                'protocol': proto, \
+                proto: {'dport': port} \
+        }
+        rule_f = { \
+                'src': dest, \
+                'dst': source, \
+                'target': 'ACCEPT', \
+                'protocol': proto, \
+                proto: {'sport': port} \
+        }
+    
+        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
+        self.assertTrue(iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
+
+        cont_mock.to_rule = rule_t
+        cont_mock.from_rule = rule_f
+        delete_container_rules(cont_mock)
+        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_output', rule_t) )
+        self.assertTrue(not iptc.easy.has_rule('filter', 'hpotter_input', rule_f) )
 
     def test_flush(self):
         flush_chains()

--- a/test/test_ssh.py
+++ b/test/test_ssh.py
@@ -1,9 +1,11 @@
 from socket import timeout
 import unittest
+import warnings
 from unittest.mock import call, patch
 
 from src.ssh import SSHServer
 from src.ssh import SshThread
+from src import chain
 
 import docker
 import socket
@@ -12,6 +14,9 @@ import time
 import paramiko
 
 class TestSSH(unittest.TestCase):
+
+    def setup(self):
+        warnings.simplefilter('ignore', category=ResourceWarning)
 
     def test_ssh(self):
         container = {'container': 'debian:sshd', 'listen_address': '0.0.0.0', 'listen_port': 2020, 'request_length': 4096, 'request_commands': 14, 'request_delimiters': ['\\r\\n'], 'threads': 2}


### PR DESCRIPTION
Re-implemented past functions which make it so docker containers spawned by HPotter cannot communicate with each other as per client request.
* functions added:
   - create_container_rules() to /src/chain.py
   - delete_container_rules() to /src/chain.py
   - these functions are called in container_thread and are therefore equipped with threadlock mechanisms
 * functions removed:
    - create_docker_rules() from /src/chain.py
    - this function allowed inter-container communication and was removed at the client's request.

Running the unittest code seems to spawn a container on port 80, unsure as to why. Does not happen during regular execution. Does not affect the unittests either (aside from making them a bit slower). 